### PR TITLE
fix "RuntimeWarning: coroutine 'search_messages' was never awaited"

### DIFF
--- a/main.py
+++ b/main.py
@@ -87,7 +87,7 @@ async def search_messages(
 
         result = resp.json()
         if "total_results" not in result:
-            return search_messages(session, chat, user, params)
+            return await search_messages(session, chat, user, params)
 
         total_results = result["total_results"]
 


### PR DESCRIPTION
This PR fix `coroutine 'search_messages' was never awaited` issue when `nuke` is initialized.